### PR TITLE
Add soft delete to comments

### DIFF
--- a/priv/repo/migrations/20170417160828_create_comment.exs
+++ b/priv/repo/migrations/20170417160828_create_comment.exs
@@ -7,6 +7,7 @@ defmodule Lift.Repo.Migrations.CreateComment do
       add :post_id,   references(:posts)
       add :parent_id, references(:comments)
       add :body,      :text
+      add :deleted,   :boolean, default: false, null: false
 
       timestamps()
     end

--- a/test/controllers/comment_controller_test.exs
+++ b/test/controllers/comment_controller_test.exs
@@ -29,5 +29,25 @@ defmodule Lift.CommentControllerTest do
     assert json_response(conn, 201)
   end
 
+  test "#delete soft deletes a comment", %{conn: conn} do
+    comment = insert(:comment)
+
+    conn = delete(conn, comment_path(conn, :delete, comment.id))
+
+    assert response(conn, 204)
+  end
+
+  test "deleted post doesn't show user and body", %{conn: conn} do
+    comment = insert(:comment, deleted: true)
+
+    conn = get(conn, comment_path(conn, :show, comment.id))
+
+    response = json_response(conn, 200)
+
+    assert response["data"]["user"] === nil
+    assert response["data"]["body"] === nil
+  end
+
+
   defp render_json(template, assigns), do: render_json(Lift.CommentView,  template, assigns)
 end

--- a/web/controllers/comment_controller.ex
+++ b/web/controllers/comment_controller.ex
@@ -46,13 +46,16 @@ defmodule Lift.CommentController do
   end
 
   def delete(conn, %{"id" => id}) do
-    # TODO: implement soft delete
     comment = Repo.get!(Comment, id)
+    changeset = Comment.changeset(comment, %{deleted: true})
 
-    # Here we use delete! (with a bang) because we expect
-    # it to always work (and if it does not, it will raise).
-    Repo.delete!(comment)
-
-    send_resp(conn, :no_content, "")
+    case Repo.update(changeset) do
+      {:ok, _comment} ->
+        send_resp(conn, :no_content, "")
+      {:error, changeset} ->
+        conn
+        |> put_status(:internal_server_error)
+        |> render(Lift.ChangesetView, "error.json", changeset: changeset)
+    end
   end
 end

--- a/web/models/comment.ex
+++ b/web/models/comment.ex
@@ -7,6 +7,7 @@ defmodule Lift.Comment do
     belongs_to :comment, Lift.Comment, foreign_key: :parent_id
 
     field :body, :string
+    field :deleted, :boolean, default: false
 
     timestamps()
   end

--- a/web/views/comment_view.ex
+++ b/web/views/comment_view.ex
@@ -10,11 +10,14 @@ defmodule Lift.CommentView do
   end
 
   def render("comment.json", %{comment: comment}) do
+    user = if comment.deleted, do: nil, else: render_one(comment.user, Lift.UserView, "user.json")
+    body = if comment.deleted, do: nil, else: comment.body
+
     %{
       id: comment.id,
       post_id: comment.post_id,
-      user: render_one(comment.user, Lift.UserView, "user.json"),
-      body: comment.body,
+      user: user,
+      body: body,
 
       created_at: comment.inserted_at,
       updated_at: comment.updated_at


### PR DESCRIPTION
Instead of actually deleting the comment, mark it as deleted and don't return data about it in the response.